### PR TITLE
opt in to texts, preferred email

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "prettier-plugin-tailwindcss": "^0.5.10",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "supabase": "^2.19.7",
+    "supabase": "^2.48.3",
     "tailwind-merge": "^2.2.0",
     "tailwindcss": "3.3.3",
     "tailwindcss-animate": "^1.0.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -147,7 +147,7 @@ importers:
         specifier: 18.2.0
         version: 18.2.0(react@18.2.0)
       supabase:
-        specifier: ^2.19.7
+        specifier: ^2.48.3
         version: 2.48.3
       tailwind-merge:
         specifier: ^2.2.0
@@ -6254,7 +6254,7 @@ snapshots:
       eslint: 8.56.0
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@8.56.0))(eslint@8.56.0)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.1.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.56.0)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.1.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.56.0)
       eslint-plugin-react: 7.37.5(eslint@8.56.0)
       eslint-plugin-react-hooks: 5.0.0-canary-7118f5dd7-20230705(eslint@8.56.0)
@@ -6284,7 +6284,7 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.1.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.56.0)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.1.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -6299,7 +6299,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.1.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.56.0):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.1.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -19,7 +19,9 @@ export default function Questionnaire() {
   const [firstname, setFirstName] = useState('')
   const [lastname, setLastName] = useState('')
   const [school, setSchool] = useState('')
+  const [email, setEmail] = useState('')
   const [phonenumber, setPhoneNumber] = useState('')
+  const [smsOptIn, setSmsOptIn] = useState(false)
   const [photo, setPhoto] = useState<File | null>(null)
   const [photoUrl, setPhotoUrl] = useState('')
   const [instagram, setInstagram] = useState('')
@@ -57,11 +59,15 @@ export default function Questionnaire() {
       if (error) {
         setMessage('Please enter your profile information.')
         console.error('Error fetching user data:', error)
+        // Set email from auth user if no profile exists
+        setEmail(user.email || '')
       } else if (data) {
         setFirstName(data.firstname || '')
         setLastName(data.lastname || '')
         setSchool(data.school || '')
+        setEmail(data.email || user.email || '')
         setPhoneNumber(data.phonenumber || '')
+        setSmsOptIn(data.sms_opt_in || false)
         setInstagram(data.instagram || '')
         setPhotoUrl(data.photo_url || '')
         setHasProfile(true)
@@ -197,11 +203,12 @@ export default function Questionnaire() {
       [
         {
           user_id: user.id,
-          email: user.email, // ✅ Automatically pulled from Supabase Auth
+          email: email, // User's preferred contact email
           firstname,
           lastname,
           school,
           phonenumber,
+          sms_opt_in: smsOptIn,
           photo_url: updatedPhotoUrl,
           instagram: instagram || null,
         },
@@ -341,6 +348,20 @@ export default function Questionnaire() {
 
                   <label className="block">
                     <span className="mb-2 block text-sm font-semibold text-gray-700 after:ml-1 after:text-red-500 after:content-['*']">
+                      Best Email to Contact
+                    </span>
+                    <input
+                      type="email"
+                      value={email}
+                      onChange={(e) => setEmail(e.target.value)}
+                      className="w-full rounded-xl border border-gray-300 bg-white/50 p-3 text-gray-900 placeholder-gray-500 transition-all duration-200 focus:border-teal-500 focus:bg-white focus:outline-none focus:ring-2 focus:ring-teal-500/20"
+                      placeholder="your.email@example.com"
+                      required
+                    />
+                  </label>
+
+                  <label className="block">
+                    <span className="mb-2 block text-sm font-semibold text-gray-700 after:ml-1 after:text-red-500 after:content-['*']">
                       Phone Number
                     </span>
                     <input
@@ -351,6 +372,18 @@ export default function Questionnaire() {
                       placeholder="(123) 456-7890"
                       required
                     />
+                  </label>
+
+                  <label className="flex items-start gap-3">
+                    <input
+                      type="checkbox"
+                      checked={smsOptIn}
+                      onChange={(e) => setSmsOptIn(e.target.checked)}
+                      className="mt-1 h-5 w-5 rounded border-gray-300 text-teal-600 transition-all duration-200 focus:ring-2 focus:ring-teal-500/20"
+                    />
+                    <span className="text-sm font-medium text-gray-700">
+                      OPT-IN to text messaging with ASPC?
+                    </span>
                   </label>
 
                   {/* <label className="block">
@@ -432,6 +465,25 @@ export default function Questionnaire() {
                       )}
                     </button>
 
+                    {/* SMS Disclaimer */}
+                    <p className="mt-4 text-xs leading-relaxed text-gray-600">
+                      By submitting this form and signing up for texts, I agree
+                      to receive conversational text messages from Associated
+                      Students of Pomona College (ASPC) using the contact
+                      information provided. For help, reply HELP. Opt out at any
+                      time by replying STOP. Message and data rates may apply.
+                      Message frequency varies. Please view our{' '}
+                      <a
+                        href="https://docs.google.com/document/d/e/2PACX-1vTUgsgoxR1HOkfnW4QYfki4DXLUSB-ELyyMqFNFfOSgxyshPE9ykZyBODVxTCip10ULXgeaqrBXGddA/pub"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-teal-600 underline hover:text-teal-700"
+                      >
+                        Privacy Policy
+                      </a>
+                      .
+                    </p>
+
                     {message && (
                       <div
                         className={`mt-4 rounded-xl p-4 text-center ${
@@ -505,6 +557,20 @@ export default function Questionnaire() {
 
                     <label className="block">
                       <span className="mb-2 block text-sm font-semibold text-gray-700 after:ml-1 after:text-red-500 after:content-['*']">
+                        Best Email to Contact
+                      </span>
+                      <input
+                        type="email"
+                        value={email}
+                        onChange={(e) => setEmail(e.target.value)}
+                        className="w-full rounded-xl border border-gray-300 bg-white/50 p-3 text-gray-900 placeholder-gray-500 transition-all duration-200 focus:border-teal-500 focus:bg-white focus:outline-none focus:ring-2 focus:ring-teal-500/20"
+                        placeholder="your.email@example.com"
+                        required
+                      />
+                    </label>
+
+                    <label className="block">
+                      <span className="mb-2 block text-sm font-semibold text-gray-700 after:ml-1 after:text-red-500 after:content-['*']">
                         Phone Number
                       </span>
                       <input
@@ -515,6 +581,18 @@ export default function Questionnaire() {
                         placeholder="(123) 456-7890"
                         required
                       />
+                    </label>
+
+                    <label className="flex items-start gap-3">
+                      <input
+                        type="checkbox"
+                        checked={smsOptIn}
+                        onChange={(e) => setSmsOptIn(e.target.checked)}
+                        className="mt-1 h-5 w-5 rounded border-gray-300 text-teal-600 transition-all duration-200 focus:ring-2 focus:ring-teal-500/20"
+                      />
+                      <span className="text-sm font-medium text-gray-700">
+                        OPT-IN to text messaging with ASPC?
+                      </span>
                     </label>
 
                     {/* <label className="block">
@@ -597,6 +675,25 @@ export default function Questionnaire() {
                           'Create Profile'
                         )}
                       </button>
+
+                      {/* SMS Disclaimer */}
+                      <p className="mt-4 text-xs leading-relaxed text-gray-600">
+                        By submitting this form and signing up for texts, I
+                        agree to receive conversational text messages from
+                        Associated Students of Pomona College (ASPC) using the
+                        contact information provided. For help, reply HELP. Opt
+                        out at any time by replying STOP. Message and data rates
+                        may apply. Message frequency varies. Please view our{' '}
+                        <a
+                          href="https://docs.google.com/document/d/e/2PACX-1vTUgsgoxR1HOkfnW4QYfki4DXLUSB-ELyyMqFNFfOSgxyshPE9ykZyBODVxTCip10ULXgeaqrBXGddA/pub"
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-teal-600 underline hover:text-teal-700"
+                        >
+                          Privacy Policy
+                        </a>
+                        .
+                      </p>
 
                       {message && (
                         <div

--- a/src/app/questionnaires/page.tsx
+++ b/src/app/questionnaires/page.tsx
@@ -25,6 +25,16 @@ export default function Questionnaires() {
   const [message, setMessage] = useState('')
   const [modalFlightId, setModalFlightId] = useState<string | null>(null)
   const [loading, setLoading] = useState(true)
+  const [smsOptIn, setSmsOptIn] = useState<boolean>(false)
+  const [smsBannerDismissed, setSmsBannerDismissed] = useState(false)
+  const [emailBannerDismissed, setEmailBannerDismissed] = useState(false)
+
+  // Check if current date is past November 16th deadline
+  const isPastDeadline = () => {
+    const today = new Date()
+    const deadline = new Date(today.getFullYear(), 10, 16) // Month is 0-indexed, so 10 = November
+    return today > deadline
+  }
   // Function to format date from yyyy-mm-dd to mm/dd/yy
   const formatDate = (dateString: string) => {
     if (!dateString) return ''
@@ -96,6 +106,28 @@ export default function Questionnaires() {
       setLoading(false)
     }
   }, [user, fetchMatchForms])
+
+  // Fetch user's SMS opt-in status
+  useEffect(() => {
+    const fetchUserPreferences = async () => {
+      if (!user) return
+
+      const { data, error } = await supabase
+        .from('Users')
+        .select('sms_opt_in')
+        .eq('user_id', user.id)
+        .single()
+
+      // Check SMS opt-in status
+      if (!error && data && data.sms_opt_in === true) {
+        setSmsOptIn(true)
+      } else {
+        setSmsOptIn(false)
+      }
+    }
+
+    fetchUserPreferences()
+  }, [user, supabase])
 
   const handleDelete = (flightId: string) => {
     setModalFlightId(flightId) // ✅ Set the specific flight ID
@@ -276,22 +308,138 @@ export default function Questionnaires() {
           </div>
         </div>
 
+        {/* Notification Banners */}
+        <div className="relative mx-auto mb-6 max-w-4xl space-y-4 px-6">
+          {/* Email Preferences Banner */}
+          {!emailBannerDismissed && (
+            <div className="flex items-start gap-3 rounded-xl border border-teal-200 bg-teal-50 p-4 shadow-sm">
+              <div className="flex-shrink-0 pt-0.5">
+                <svg
+                  className="h-5 w-5 text-teal-600"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"
+                  />
+                </svg>
+              </div>
+              <div className="flex-1">
+                <h3 className="font-semibold text-teal-900">
+                  📧 Update Your Preferred Email
+                </h3>
+                <p className="mt-1 text-sm text-teal-800">
+                  Add your best contact email to stay informed about your rides
+                  and important updates.
+                </p>
+              </div>
+              <a
+                href="/profile"
+                className="flex-shrink-0 rounded-lg bg-teal-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-teal-700"
+              >
+                Update Profile
+              </a>
+              <button
+                onClick={() => setEmailBannerDismissed(true)}
+                className="flex-shrink-0 text-teal-600 transition-colors hover:text-teal-800"
+                aria-label="Dismiss banner"
+              >
+                <svg
+                  className="h-5 w-5"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M6 18L18 6M6 6l12 12"
+                  />
+                </svg>
+              </button>
+            </div>
+          )}
+
+          {/* SMS Opt-in Banner */}
+          {!smsOptIn && !smsBannerDismissed && (
+            <div className="flex items-start gap-3 rounded-xl border border-teal-200 bg-teal-50 p-4 shadow-sm">
+              <div className="flex-shrink-0 pt-0.5">
+                <svg
+                  className="h-5 w-5 text-teal-600"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M12 18h.01M8 21h8a2 2 0 002-2V5a2 2 0 00-2-2H8a2 2 0 00-2 2v14a2 2 0 002 2z"
+                  />
+                </svg>
+              </div>
+              <div className="flex-1">
+                <h3 className="font-semibold text-teal-900">
+                  📱 Stay Updated with Text Notifications
+                </h3>
+                <p className="mt-1 text-sm text-teal-800">
+                  Opt in to receive important updates about your rides from
+                  ASPC.
+                </p>
+              </div>
+              <a
+                href="/profile"
+                className="flex-shrink-0 rounded-lg bg-teal-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-teal-700"
+              >
+                Update Profile
+              </a>
+              <button
+                onClick={() => setSmsBannerDismissed(true)}
+                className="flex-shrink-0 text-teal-600 transition-colors hover:text-teal-800"
+                aria-label="Dismiss banner"
+              >
+                <svg
+                  className="h-5 w-5"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M6 18L18 6M6 6l12 12"
+                  />
+                </svg>
+              </button>
+            </div>
+          )}
+        </div>
+
         {/* Action Buttons */}
         <div className="relative mb-8 flex flex-col items-center gap-4">
           <div className="flex flex-wrap justify-center gap-4">
             <RedirectButton label="Update Profile" route="/profile" />
-            {/* <RedirectButton label="Request Match" route="/matchForm" /> */}
-            <div className="flex flex-col items-center">
-              <button
-                disabled
-                className="mt-4 cursor-not-allowed rounded-lg bg-gray-400 px-6 py-3 text-lg font-semibold text-white opacity-60"
-              >
-                Request Match
-              </button>
-              <p className="mt-2 text-center text-sm text-gray-500">
-                Sorry! You&apos;re past the deadline for fall break
-              </p>
-            </div>
+            {isPastDeadline() ? (
+              <div className="flex flex-col items-center">
+                <button
+                  disabled
+                  className="mt-4 cursor-not-allowed rounded-lg bg-gray-400 px-6 py-3 text-lg font-semibold text-white opacity-60"
+                >
+                  Request Match
+                </button>
+                <p className="mt-2 text-center text-sm text-gray-500">
+                  Sorry! You&apos;re past the deadline for signing up
+                </p>
+              </div>
+            ) : (
+              <RedirectButton label="Request Match" route="/matchForm" />
+            )}
           </div>
         </div>
 

--- a/src/components/results/CommentSection.tsx
+++ b/src/components/results/CommentSection.tsx
@@ -32,7 +32,7 @@ export default function CommentSection({ rideId }: { rideId: number }) {
         const { data, error } = await supabase
           .from('Users')
           .select(
-            'user_id, created_at, firstname, lastname, phonenumber, school, photo_url, instagram, email',
+            'user_id, created_at, firstname, lastname, phonenumber, school, photo_url, instagram, email, sms_opt_in',
           )
           .eq('user_id', user.id)
           .single()

--- a/src/lib/database.types.ts
+++ b/src/lib/database.types.ts
@@ -12,6 +12,7 @@ export type Database = {
           photo_url: string
           instagram: string
           email: string
+          sms_opt_in: boolean
         }
       }
       Matches: {


### PR DESCRIPTION
privacy policy at profile page, opt in, preferred email, modals on questionnaire page to encourage ppl to update profile

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds preferred email and SMS opt-in to profiles, shows dismissible update banners on questionnaires, enforces request deadline/cutoffs, updates DB types, and bumps Supabase.
> 
> - **Profile (`src/app/profile/page.tsx`)**:
>   - Add "Best Email to Contact" field; prefill from profile/auth and persist as `email`.
>   - Add SMS opt-in checkbox; load/save `sms_opt_in`; include SMS disclaimer with Privacy Policy link.
>   - Adjust upsert to store `email` and `sms_opt_in`.
> - **Questionnaires (`src/app/questionnaires/page.tsx`)**:
>   - Fetch user `sms_opt_in` and show dismissible banners prompting email update and SMS opt-in (links to `/profile`).
>   - Add deadline gating: disable "Request Match" past Nov 16; new editability cutoff logic (editable until `2025-10-04`).
> - **Data/Types (`src/lib/database.types.ts`)**:
>   - Extend `Users` row with `sms_opt_in: boolean`.
> - **Dependencies**:
>   - Bump `supabase` to `^2.48.3` (lockfile updated).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5c1c10a1395c4f8180365579da02e06cc415cbdb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->