### PR TITLE
small policy changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "typescript"
   ],
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev -H 0.0.0.0",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",

--- a/src/app/aspc-info/page.tsx
+++ b/src/app/aspc-info/page.tsx
@@ -98,13 +98,46 @@ export default function ASPCInfoPage() {
             <p className="mb-4 text-lg text-gray-600">
               Information & Resources for Pomona College Students
             </p>
-            <div className="mx-auto max-w-2xl rounded-lg border border-blue-200 bg-blue-50 p-4">
-              <p className="text-sm text-blue-800">
-                <strong>Contact:</strong> operations@aspc.pomona.edu
-              </p>
-              <p className="mt-1 text-sm text-blue-700">
-                For questions about ASPC&apos;s Airport Rideshare Program
-              </p>
+            <div className="mx-auto max-w-2xl rounded-lg border border-teal-200 bg-gradient-to-br from-teal-50 to-blue-50 p-6 shadow-md">
+              <div className="mb-4 rounded-lg bg-white/70 p-4 backdrop-blur-sm">
+                <p className="text-base font-bold text-teal-900">
+                  Need day-of-travel RideLink support?
+                </p>
+                <p className="mt-2 text-lg font-bold text-teal-800">
+                  Call/text:{' '}
+                  <a
+                    href="tel:9093475295"
+                    className="text-xl text-teal-700 underline transition-colors hover:text-teal-900"
+                  >
+                    909-347-5295
+                  </a>
+                </p>
+              </div>
+              <div className="space-y-2 text-sm">
+                <p className="text-gray-700">
+                  <strong className="text-gray-800">Email:</strong>{' '}
+                  <a
+                    href="mailto:operations@aspc.pomona.edu"
+                    className="text-blue-700 hover:underline"
+                  >
+                    operations@aspc.pomona.edu
+                  </a>
+                </p>
+                <p className="text-gray-600">
+                  For questions about ASPC&apos;s Airport Rideshare Program
+                </p>
+                <p className="border-t border-gray-300 pt-3 text-gray-700">
+                  View our{' '}
+                  <a
+                    href="https://docs.google.com/document/d/e/2PACX-1vTUgsgoxR1HOkfnW4QYfki4DXLUSB-ELyyMqFNFfOSgxyshPE9ykZyBODVxTCip10ULXgeaqrBXGddA/pub"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="font-semibold text-teal-700 underline hover:text-teal-900"
+                  >
+                    Privacy Policy
+                  </a>
+                </p>
+              </div>
             </div>
           </div>
         </div>

--- a/src/app/aspc-policy/page.tsx
+++ b/src/app/aspc-policy/page.tsx
@@ -41,115 +41,157 @@ export default function ASPCPolicy() {
               </svg>
             </div>
             <h1 className="mb-4 text-4xl font-bold text-gray-900">
-              ASPC Subsidy Policy
+              ASPC RideLink Policy
             </h1>
             <p className="text-xl text-gray-600">
-              Fall 2025 Operational Guidelines
+              2025-2026 Operational Guidelines
             </p>
           </div>
 
           {/* Policy Content */}
           <div className="rounded-3xl bg-white/80 p-8 shadow-2xl backdrop-blur-sm">
+            {/* Contact Info */}
+            <div className="mb-8 rounded-xl bg-gradient-to-r from-teal-50 to-blue-50 p-6">
+              <p className="text-center text-gray-700">
+                <strong>Questions?</strong> Contact{' '}
+                <a
+                  href="mailto:ridelink@aspc.pomona.edu"
+                  className="font-semibold text-teal-700 hover:underline"
+                >
+                  ridelink@aspc.pomona.edu
+                </a>
+              </p>
+            </div>
+
             {/* Operational Periods */}
             <div className="mb-8">
               <h2 className="mb-4 text-2xl font-bold text-gray-900">
-                📅 Fall 2025 Operational Periods
+                📅 Operational Periods
               </h2>
-              <div className="rounded-xl bg-gradient-to-r from-teal-50 to-blue-50 p-6">
-                <h3 className="mb-3 text-lg font-semibold text-gray-800">
-                  Fall Break - October 11, 13, 14 (ONT Only)
+
+              {/* Thanksgiving Break */}
+              <div className="mb-6 rounded-xl bg-gradient-to-r from-orange-50 to-amber-50 p-6">
+                <h3 className="mb-3 text-xl font-semibold text-gray-800">
+                  🦃 Thanksgiving Break
                 </h3>
-                <p className="text-gray-700">
-                  ASPC-subsidized rides are only available on these specific
-                  dates.
-                </p>
-              </div>
-            </div>
-
-            {/* Time Windows */}
-            <div className="mb-8">
-              <h2 className="mb-4 text-2xl font-bold text-gray-900">
-                ⏰ Guaranteed Subsidy Time Windows
-              </h2>
-
-              <div className="grid gap-6 md:grid-cols-2">
-                {/* Outbound */}
-                <div className="to-emerald-50 rounded-xl bg-gradient-to-br from-green-50 p-6">
-                  <h3 className="mb-3 text-lg font-semibold text-gray-800">
-                    🛫 Outbound (To Airport)
-                  </h3>
-                  <div className="space-y-2">
+                <div className="space-y-3">
+                  <div>
+                    <p className="font-semibold text-gray-800">
+                      Deadline to request:
+                    </p>
                     <p className="text-gray-700">
-                      <span className="font-semibold">Guaranteed:</span> 6:00 AM
-                      - 6:00 PM PST
+                      Friday, November 14, 2025 at 11:59 PM PST
                     </p>
                   </div>
-                </div>
-
-                {/* Inbound */}
-                <div className="rounded-xl bg-gradient-to-br from-blue-50 to-indigo-50 p-6">
-                  <h3 className="mb-3 text-lg font-semibold text-gray-800">
-                    🛬 Inbound (Return to Campus)
-                  </h3>
-                  <div className="space-y-2">
-                    <p className="text-gray-700">
-                      <span className="font-semibold">Guaranteed:</span> 10:00
-                      AM - 10:00 PM PST
+                  <div>
+                    <p className="font-semibold text-gray-800">
+                      Service Window:
                     </p>
+                    <ul className="ml-5 list-disc space-y-1 text-gray-700">
+                      <li>Departures: November 21-26</li>
+                      <li>Returns: November 29-December 1</li>
+                    </ul>
                   </div>
                 </div>
               </div>
+
+              {/* Winter Break Departure */}
+              <div className="mb-6 rounded-xl bg-gradient-to-r from-blue-50 to-indigo-50 p-6">
+                <h3 className="mb-3 text-xl font-semibold text-gray-800">
+                  ❄️ Winter Break Departure
+                </h3>
+                <div className="space-y-3">
+                  <div>
+                    <p className="font-semibold text-gray-800">
+                      Deadline to request:
+                    </p>
+                    <p className="text-gray-700">
+                      Wednesday, December 3, 2025 at 11:59 PM PST
+                    </p>
+                  </div>
+                  <div>
+                    <p className="font-semibold text-gray-800">
+                      Service Window:
+                    </p>
+                    <p className="text-gray-700">December 9-13</p>
+                  </div>
+                  <div className="rounded-lg bg-yellow-100 p-3">
+                    <p className="text-sm font-semibold text-yellow-900">
+                      ⚠️ Pomona College dorms and facilities close at 12:00 PM
+                      on December 13.
+                    </p>
+                  </div>
+                </div>
+              </div>
+
+              {/* Winter Break Return */}
+              <div className="rounded-xl bg-gradient-to-r from-teal-50 to-cyan-50 p-6">
+                <h3 className="mb-3 text-xl font-semibold text-gray-800">
+                  🎉 Winter Break Return
+                </h3>
+                <div className="space-y-3">
+                  <div>
+                    <p className="font-semibold text-gray-800">
+                      Deadline to request:
+                    </p>
+                    <p className="text-gray-700">
+                      Friday, January 9, 2026 at 11:59 PM PST
+                    </p>
+                  </div>
+                  <div>
+                    <p className="font-semibold text-gray-800">
+                      Service Window:
+                    </p>
+                    <p className="text-gray-700">January 17-21</p>
+                  </div>
+                </div>
+              </div>
             </div>
 
-            {/* After Hours Policy */}
+            {/* How Matching Works */}
             <div className="mb-8">
               <h2 className="mb-4 text-2xl font-bold text-gray-900">
-                🌙 After Hours Requests
+                🤝 How Matching Works
               </h2>
-              <div className="rounded-xl bg-gradient-to-r from-yellow-50 to-orange-50 p-6">
+              <div className="rounded-xl bg-gradient-to-r from-purple-50 to-pink-50 p-6">
                 <p className="mb-4 text-gray-700">
-                  If your flight falls outside guaranteed hours but is still on
-                  an operational day, or ±2 days from our coverage, we will
-                  cover it if:
+                  RideLink covers rides only when groups can be formed:{' '}
+                  <span className="font-bold">2+ riders to ONT</span> or{' '}
+                  <span className="font-bold">3+ riders to LAX</span>.
                 </p>
-                <div className="grid gap-4 md:grid-cols-2">
-                  <div className="rounded-lg bg-white/50 p-4">
-                    <h4 className="font-semibold text-gray-800">ONT Airport</h4>
-                    <p className="text-gray-700">
-                      At least <span className="font-bold">2 riders</span> must
-                      be grouped
-                    </p>
-                  </div>
-                  <div className="rounded-lg bg-white/50 p-4">
-                    <h4 className="font-semibold text-gray-800">LAX Airport</h4>
-                    <p className="text-gray-700">
-                      At least <span className="font-bold">3 riders</span> must
-                      be grouped
-                    </p>
-                  </div>
+                <div className="rounded-lg bg-white/70 p-4">
+                  <p className="mb-3 font-semibold text-gray-800">
+                    💡 Tips to Increase Your Matching Odds:
+                  </p>
+                  <ul className="space-y-2 text-gray-700">
+                    <li className="flex items-start">
+                      <span className="mr-2 text-teal-500">•</span>
+                      <span>
+                        <strong>Travel during common times:</strong> Daytime
+                        hours and within ±1 day of the start or end of the break
+                      </span>
+                    </li>
+                    <li className="flex items-start">
+                      <span className="mr-2 text-teal-500">•</span>
+                      <span>
+                        <strong>Be flexible:</strong> Provide a wide range of
+                        availability and be willing to arrive at the airport
+                        earlier than necessary
+                      </span>
+                    </li>
+                    <li className="flex items-start">
+                      <span className="mr-2 text-teal-500">•</span>
+                      <span>
+                        <strong>Encourage friends:</strong> More riders = more
+                        matches! Get your friends to sign up
+                      </span>
+                    </li>
+                  </ul>
                 </div>
                 <p className="mt-4 text-sm text-gray-600">
-                  If grouping cannot be achieved, the ride will not be
-                  subsidized. PICKUP will notify you at least 5 days before
-                  travel. Students may still use P-ICKUP.com to coordinate
-                  non-subsidized rides and split costs among themselves.
-                </p>
-              </div>
-            </div>
-
-            {/* Non-Covered Days */}
-            <div className="mb-8">
-              <h2 className="mb-4 text-2xl font-bold text-gray-900">
-                ❌ Non-Covered Days
-              </h2>
-              <div className="rounded-xl bg-gradient-to-r from-red-50 to-pink-50 p-6">
-                <p className="text-gray-700">
-                  Flights outside operational periods (more than ±2 days from
-                  the published schedule) are not eligible for subsidy.
-                </p>
-                <p className="mt-2 text-gray-700">
-                  Students may still use P-ICKUP.com to coordinate
-                  non-subsidized rides and split costs among themselves.
+                  If a sufficient group cannot be formed, RideLink will be
+                  unable to cover the ride. However, you may still use PICKUP to
+                  coordinate non-subsidized carpools.
                 </p>
               </div>
             </div>

--- a/src/app/questionnaires/page.tsx
+++ b/src/app/questionnaires/page.tsx
@@ -312,40 +312,10 @@ export default function Questionnaires() {
         <div className="relative mx-auto mb-6 max-w-4xl space-y-4 px-6">
           {/* Email Preferences Banner */}
           {!emailBannerDismissed && (
-            <div className="flex items-start gap-3 rounded-xl border border-teal-200 bg-teal-50 p-4 shadow-sm">
-              <div className="flex-shrink-0 pt-0.5">
-                <svg
-                  className="h-5 w-5 text-teal-600"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"
-                  />
-                </svg>
-              </div>
-              <div className="flex-1">
-                <h3 className="font-semibold text-teal-900">
-                  📧 Update Your Preferred Email
-                </h3>
-                <p className="mt-1 text-sm text-teal-800">
-                  Add your best contact email to stay informed about your rides
-                  and important updates.
-                </p>
-              </div>
-              <a
-                href="/profile"
-                className="flex-shrink-0 rounded-lg bg-teal-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-teal-700"
-              >
-                Update Profile
-              </a>
+            <div className="relative rounded-xl border border-teal-200 bg-teal-50 p-4 shadow-sm">
               <button
                 onClick={() => setEmailBannerDismissed(true)}
-                className="flex-shrink-0 text-teal-600 transition-colors hover:text-teal-800"
+                className="absolute right-3 top-3 text-teal-600 transition-colors hover:text-teal-800"
                 aria-label="Dismiss banner"
               >
                 <svg
@@ -362,45 +332,47 @@ export default function Questionnaires() {
                   />
                 </svg>
               </button>
+              <div className="flex items-start gap-3 pr-8">
+                <div className="hidden flex-shrink-0 pt-0.5 sm:block">
+                  <svg
+                    className="h-5 w-5 text-teal-600"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"
+                    />
+                  </svg>
+                </div>
+                <div className="flex-1">
+                  <h3 className="font-semibold text-teal-900">
+                    📧 Update Your Preferred Email
+                  </h3>
+                  <p className="mt-1 text-sm text-teal-800">
+                    Add your best contact email to stay informed about your
+                    rides and important updates.
+                  </p>
+                  <a
+                    href="/profile"
+                    className="mt-3 inline-block w-full rounded-lg bg-teal-600 px-4 py-2 text-center text-sm font-medium text-white transition-colors hover:bg-teal-700 sm:w-auto"
+                  >
+                    Update Profile
+                  </a>
+                </div>
+              </div>
             </div>
           )}
 
           {/* SMS Opt-in Banner */}
           {!smsOptIn && !smsBannerDismissed && (
-            <div className="flex items-start gap-3 rounded-xl border border-teal-200 bg-teal-50 p-4 shadow-sm">
-              <div className="flex-shrink-0 pt-0.5">
-                <svg
-                  className="h-5 w-5 text-teal-600"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M12 18h.01M8 21h8a2 2 0 002-2V5a2 2 0 00-2-2H8a2 2 0 00-2 2v14a2 2 0 002 2z"
-                  />
-                </svg>
-              </div>
-              <div className="flex-1">
-                <h3 className="font-semibold text-teal-900">
-                  📱 Stay Updated with Text Notifications
-                </h3>
-                <p className="mt-1 text-sm text-teal-800">
-                  Opt in to receive important updates about your rides from
-                  ASPC.
-                </p>
-              </div>
-              <a
-                href="/profile"
-                className="flex-shrink-0 rounded-lg bg-teal-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-teal-700"
-              >
-                Update Profile
-              </a>
+            <div className="relative rounded-xl border border-teal-200 bg-teal-50 p-4 shadow-sm">
               <button
                 onClick={() => setSmsBannerDismissed(true)}
-                className="flex-shrink-0 text-teal-600 transition-colors hover:text-teal-800"
+                className="absolute right-3 top-3 text-teal-600 transition-colors hover:text-teal-800"
                 aria-label="Dismiss banner"
               >
                 <svg
@@ -417,6 +389,38 @@ export default function Questionnaires() {
                   />
                 </svg>
               </button>
+              <div className="flex items-start gap-3 pr-8">
+                <div className="hidden flex-shrink-0 pt-0.5 sm:block">
+                  <svg
+                    className="h-5 w-5 text-teal-600"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M12 18h.01M8 21h8a2 2 0 002-2V5a2 2 0 00-2-2H8a2 2 0 00-2 2v14a2 2 0 002 2z"
+                    />
+                  </svg>
+                </div>
+                <div className="flex-1">
+                  <h3 className="font-semibold text-teal-900">
+                    📱 Stay Updated with Text Notifications
+                  </h3>
+                  <p className="mt-1 text-sm text-teal-800">
+                    Opt in to receive important updates about your rides from
+                    ASPC.
+                  </p>
+                  <a
+                    href="/profile"
+                    className="mt-3 inline-block w-full rounded-lg bg-teal-600 px-4 py-2 text-center text-sm font-medium text-white transition-colors hover:bg-teal-700 sm:w-auto"
+                  >
+                    Update Profile
+                  </a>
+                </div>
+              </div>
             </div>
           )}
         </div>


### PR DESCRIPTION
- added phone number and changed contact email
- updated aspc subsidy policy page
- mobile style for pop ups on questionnaire page

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Overhauls the RideLink policy page with 2025–2026 details, adds day-of support phone and updated contact info, refines questionnaire notification banners for mobile, and binds dev server to 0.0.0.0.
> 
> - **Policy**:
>   - **`src/app/aspc-policy/page.tsx`**: Renames to “ASPC RideLink Policy” and updates to 2025–2026 guidelines.
>     - Adds contact block (`ridelink@aspc.pomona.edu`).
>     - Defines operational periods (Thanksgiving, Winter Departure/Return) with deadlines and windows.
>     - Adds “How Matching Works” with group-size rules and tips.
> - **Info Page**:
>   - **`src/app/aspc-info/page.tsx`**: Replaces contact box with day-of support phone (`tel:9093475295`), email link, and Privacy Policy link; refreshed styling.
> - **Questionnaires UI**:
>   - **`src/app/questionnaires/page.tsx`**: Redesigns email/SMS banners (dismiss button placement, responsive CTA styling) for better mobile UX.
> - **Dev**:
>   - **`package.json`**: Binds dev server to `0.0.0.0` via `next dev -H 0.0.0.0`.}
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 65574cbf05645766776b4615d0a633d0daf0061a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->