### PR TITLE
flight form fix

### DIFF
--- a/src/components/forms/FlightForm.tsx
+++ b/src/components/forms/FlightForm.tsx
@@ -628,7 +628,11 @@ export default function FlightForm({
             )}
 
             <label className="mb-2 block">
-              <span className="font-bold">Flight Date:</span>
+              <span className="font-bold">
+                {tripType
+                  ? "Earliest Date You're Able to Leave to the Airport:"
+                  : "Earliest Date You're Able to Leave from the Airport:"}
+              </span>
               <input
                 type="date"
                 value={dateOfFlight}
@@ -650,6 +654,12 @@ export default function FlightForm({
                 </a>
               </div>
             )}
+
+            <p className="mt-1 text-sm text-gray-600">
+              This is the first date of your availability. If your time range
+              extends overnight or across multiple days, choose the earliest
+              date and specify times below.
+            </p>
 
             <div className="mb-2">
               <label className="mb-2 block">


### PR DESCRIPTION
emergency fix to make sure users know what to put if date extends overnight

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Clarifies the flight date field label based on trip direction and adds a short note explaining how to choose a date for overnight or multi-day availability.
> 
> - **Flight Form (`src/components/forms/FlightForm.tsx`)**:
>   - Update date label to context-aware text based on `tripType` (leave to/from airport).
>   - Add explanatory note below date field on selecting earliest date when time range spans overnight/multiple days.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 19cc9999f0e74d8cddc9b4096ed62dc322558066. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->