### PR TITLE
Small visual fixes

### DIFF
--- a/src/components/PickupHeader.tsx
+++ b/src/components/PickupHeader.tsx
@@ -53,30 +53,42 @@ export default function PickupHeader() {
           </div>
           {/* Dashboard button - always rendered to prevent layout shift, hidden on mobile */}
           <div
-            className={`hidden rounded-lg bg-white/10 px-1 py-1 backdrop-blur-sm transition-opacity duration-200 md:block ${
+            className={`hidden transition-opacity duration-200 md:block ${
               isAdmin
                 ? 'pointer-events-auto opacity-100'
                 : 'pointer-events-none opacity-0'
             }`}
           >
-            <SimpleRedirectButton label="Dashboard" route="/admin" />
+            <SimpleRedirectButton
+              label="Dashboard"
+              route="/admin"
+              variant="nav"
+            />
           </div>
         </div>
 
         {/* Desktop Navigation */}
         <nav className="hidden space-x-1 md:flex lg:space-x-3">
-          <div className="rounded-lg bg-white/10 px-1 py-1 backdrop-blur-sm">
-            <SimpleRedirectButton label="Forms" route="/questionnaires" />
-          </div>
-          <div className="rounded-lg bg-white/10 px-1 py-1 backdrop-blur-sm">
-            <SimpleRedirectButton label="Results" route="/results" />
-          </div>
-          <div className="rounded-lg bg-white/10 px-1 py-1 backdrop-blur-sm">
-            <SimpleRedirectButton label="Unmatched" route="/unmatched" />
-          </div>
-          <div className="rounded-lg bg-white/10 px-1 py-1 backdrop-blur-sm">
-            <SimpleRedirectButton label="Feedback" route="/feedback" />
-          </div>
+          <SimpleRedirectButton
+            label="Forms"
+            route="/questionnaires"
+            variant="nav"
+          />
+          <SimpleRedirectButton
+            label="Results"
+            route="/results"
+            variant="nav"
+          />
+          <SimpleRedirectButton
+            label="Unmatched"
+            route="/unmatched"
+            variant="nav"
+          />
+          <SimpleRedirectButton
+            label="Feedback"
+            route="/feedback"
+            variant="nav"
+          />
         </nav>
 
         {/* Mobile Navigation - Hamburger Menu */}
@@ -178,53 +190,38 @@ export default function PickupHeader() {
       {/* Mobile Dropdown Menu */}
       {isMobileMenuOpen && (
         <div className="border-t border-white/20 bg-gradient-to-r from-teal-500 to-yellow-100 md:hidden">
-          <div className="space-y-3 px-4 py-4">
-            <button
-              onClick={() => {
-                router.push('/questionnaires')
-                setIsMobileMenuOpen(false)
-              }}
-              className="block w-full py-2 text-left text-white transition-colors hover:text-yellow-200"
-            >
-              📋 Questionnaire
-            </button>
-            <button
-              onClick={() => {
-                router.push('/results')
-                setIsMobileMenuOpen(false)
-              }}
-              className="block w-full py-2 text-left text-white transition-colors hover:text-yellow-200"
-            >
-              🎯 Results
-            </button>
-            <button
-              onClick={() => {
-                router.push('/unmatched')
-                setIsMobileMenuOpen(false)
-              }}
-              className="block w-full py-2 text-left text-white transition-colors hover:text-yellow-200"
-            >
-              👥 Unmatched
-            </button>
-            <button
-              onClick={() => {
-                router.push('/feedback')
-                setIsMobileMenuOpen(false)
-              }}
-              className="block w-full py-2 text-left text-white transition-colors hover:text-yellow-200"
-            >
-              💬 Feedback
-            </button>
+          <div className="space-y-1 px-4 py-4">
+            <SimpleRedirectButton
+              label="📋 Questionnaire"
+              route="/questionnaires"
+              variant="mobile"
+              onNavigate={() => setIsMobileMenuOpen(false)}
+            />
+            <SimpleRedirectButton
+              label="🎯 Results"
+              route="/results"
+              variant="mobile"
+              onNavigate={() => setIsMobileMenuOpen(false)}
+            />
+            <SimpleRedirectButton
+              label="👥 Unmatched"
+              route="/unmatched"
+              variant="mobile"
+              onNavigate={() => setIsMobileMenuOpen(false)}
+            />
+            <SimpleRedirectButton
+              label="💬 Feedback"
+              route="/feedback"
+              variant="mobile"
+              onNavigate={() => setIsMobileMenuOpen(false)}
+            />
             {isAdmin && (
-              <button
-                onClick={() => {
-                  router.push('/admin')
-                  setIsMobileMenuOpen(false)
-                }}
-                className="block w-full py-2 text-left text-white transition-colors hover:text-yellow-200"
-              >
-                🔐 Dashboard
-              </button>
+              <SimpleRedirectButton
+                label="🔐 Dashboard"
+                route="/admin"
+                variant="mobile"
+                onNavigate={() => setIsMobileMenuOpen(false)}
+              />
             )}
           </div>
         </div>

--- a/src/components/admin/AdminDashboard.test.tsx
+++ b/src/components/admin/AdminDashboard.test.tsx
@@ -28,6 +28,7 @@ jest.mock('next/navigation', () => ({
   useRouter: () => ({
     push: pushMock,
   }),
+  usePathname: () => '/admin',
 }))
 
 import AdminDashboard from '@/components/admin/AdminDashboard'
@@ -404,15 +405,15 @@ describe('AdminDashboard', () => {
     expect(await screen.findByText('Scheduled (All)')).toBeInTheDocument()
   })
 
-  it('navigates to groups management from the action button', async () => {
+  it('links to groups management from the action button', async () => {
     renderDashboard()
 
     await screen.findByText('Pickup Dashboard')
-    await userEvent.click(
-      screen.getByRole('button', { name: /View & Manage Groups/i }),
-    )
+    const groupsLink = screen.getByRole('link', {
+      name: /View & Manage Groups/i,
+    })
 
-    expect(pushMock).toHaveBeenCalledWith('/admin/groups')
+    expect(groupsLink).toHaveAttribute('href', '/admin/groups')
   })
 
   it('runs the match email dry run through the server route', async () => {

--- a/src/components/admin/AdminDashboard.tsx
+++ b/src/components/admin/AdminDashboard.tsx
@@ -2,8 +2,8 @@
 
 import type { AdminSummaryDto } from '@/contracts/readModels'
 import type { NoShowRiderInfo } from '@/utils/adminMatchNoShows'
+import SimpleRedirectButton from '@/components/buttons/SimpleRedirectButton'
 import { postJson, requestJson } from '@/utils/api'
-import { useRouter } from 'next/navigation'
 import { useEffect, useState } from 'react'
 
 const formatDateTime = (dateString: string): string => {
@@ -45,7 +45,6 @@ const getDefaultUnmatchedDateWindow = () => {
 }
 
 export default function AdminDashboard() {
-  const router = useRouter()
   const [loading, setLoading] = useState(true)
   const [school, setSchool] = useState<string>('')
   const [matchRate, setMatchRate] = useState<number>(0)
@@ -420,10 +419,6 @@ export default function AdminDashboard() {
     }
   }
 
-  const handleViewGroups = () => {
-    router.push('/admin/groups')
-  }
-
   const fetchCancellations = async () => {
     if (!cancellationsDateStart || !cancellationsDateEnd) return
     setCancellationsLoading(true)
@@ -592,12 +587,11 @@ export default function AdminDashboard() {
         </div>
 
         <div className="mb-8 flex flex-wrap justify-center gap-4">
-          <button
-            onClick={handleViewGroups}
-            className="rounded-lg bg-gradient-to-r from-teal-500 to-cyan-500 px-6 py-3 font-medium text-white transition-all hover:from-teal-600 hover:to-cyan-600"
-          >
-            View & Manage Groups
-          </button>
+          <SimpleRedirectButton
+            label="View & Manage Groups"
+            route="/admin/groups"
+            variant="cta"
+          />
         </div>
 
         {/* Match no-shows — warm orange–yellow banner (Cancellations keeps red–orange) */}

--- a/src/components/buttons/SimpleRedirectButton.tsx
+++ b/src/components/buttons/SimpleRedirectButton.tsx
@@ -1,23 +1,101 @@
 'use client'
 
-import { useRouter } from 'next/navigation'
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+import { useEffect, useState } from 'react'
 
 interface SimpleRedirectButtonProps {
   label: string
   route: string
+  variant?: 'plain' | 'nav' | 'mobile'
+  onNavigate?: () => void
+  className?: string
+}
+
+function isRouteActive(pathname: string, route: string) {
+  return pathname === route || pathname.startsWith(`${route}/`)
 }
 
 const SimpleRedirectButton: React.FC<SimpleRedirectButtonProps> = ({
   label,
   route,
+  variant = 'plain',
+  onNavigate,
+  className = '',
 }) => {
-  const router = useRouter()
+  const pathname = usePathname()
+  const [isNavigating, setIsNavigating] = useState(false)
+  const isActive = isRouteActive(pathname, route)
 
-  return (
-    <button onClick={() => router.push(route)} className="hover:text-yellow-50">
+  useEffect(() => {
+    setIsNavigating(false)
+  }, [pathname])
+
+  const handleClick = (event: React.MouseEvent<HTMLAnchorElement>) => {
+    if (isActive) {
+      event.preventDefault()
+      return
+    }
+
+    setIsNavigating(true)
+    onNavigate?.()
+  }
+
+  const linkClassName = [
+    'items-center gap-1.5 transition-all duration-150',
+    variant === 'mobile' ? 'flex w-full' : 'inline-flex',
+    'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/50',
+    variant === 'nav' && 'group-hover:text-yellow-100',
+    variant !== 'nav' && 'hover:text-yellow-50',
+    variant === 'mobile' &&
+      'rounded-lg px-2 py-2 text-left hover:bg-white/10 active:bg-white/20',
+    variant === 'plain' && 'hover:underline',
+    isActive && 'text-yellow-50',
+    isActive && variant === 'mobile' && 'bg-white/15',
+    isNavigating && 'pointer-events-none scale-[0.98] opacity-75',
+    className,
+  ]
+    .filter(Boolean)
+    .join(' ')
+
+  const link = (
+    <Link
+      href={route}
+      onClick={handleClick}
+      aria-current={isActive ? 'page' : undefined}
+      aria-busy={isNavigating}
+      className={linkClassName}
+    >
+      {isNavigating && (
+        <span
+          className="h-3 w-3 shrink-0 animate-spin rounded-full border-2 border-white/30 border-t-white"
+          aria-hidden="true"
+        />
+      )}
       {label}
-    </button>
+    </Link>
   )
+
+  if (variant === 'nav') {
+    return (
+      <div
+        className={[
+          'group cursor-pointer rounded-lg bg-white/10 px-1 py-1 backdrop-blur-sm transition-all duration-150',
+          'hover:bg-white/25 hover:ring-1 hover:ring-white/40',
+          'active:scale-95',
+          isActive && 'bg-white/20 shadow-inner ring-1 ring-white/30',
+          isActive && 'hover:bg-white/30',
+          isNavigating && 'bg-white/25 opacity-75',
+        ]
+          .filter(Boolean)
+          .join(' ')}
+      >
+        {link}
+      </div>
+    )
+  }
+
+  return link
 }
 
 export default SimpleRedirectButton

--- a/src/components/buttons/SimpleRedirectButton.tsx
+++ b/src/components/buttons/SimpleRedirectButton.tsx
@@ -7,13 +7,17 @@ import { useEffect, useState } from 'react'
 interface SimpleRedirectButtonProps {
   label: string
   route: string
-  variant?: 'plain' | 'nav' | 'mobile'
+  variant?: 'plain' | 'nav' | 'mobile' | 'cta'
   onNavigate?: () => void
   className?: string
 }
 
 function isRouteActive(pathname: string, route: string) {
   return pathname === route || pathname.startsWith(`${route}/`)
+}
+
+function isExactRoute(pathname: string, route: string) {
+  return pathname === route
 }
 
 const SimpleRedirectButton: React.FC<SimpleRedirectButtonProps> = ({
@@ -26,13 +30,14 @@ const SimpleRedirectButton: React.FC<SimpleRedirectButtonProps> = ({
   const pathname = usePathname()
   const [isNavigating, setIsNavigating] = useState(false)
   const isActive = isRouteActive(pathname, route)
+  const isCurrentPage = isExactRoute(pathname, route)
 
   useEffect(() => {
     setIsNavigating(false)
   }, [pathname])
 
   const handleClick = (event: React.MouseEvent<HTMLAnchorElement>) => {
-    if (isActive) {
+    if (isCurrentPage) {
       event.preventDefault()
       return
     }
@@ -42,16 +47,18 @@ const SimpleRedirectButton: React.FC<SimpleRedirectButtonProps> = ({
   }
 
   const linkClassName = [
-    'items-center gap-1.5 transition-all duration-150',
+    'items-center gap-2 transition-all duration-150',
     variant === 'mobile' ? 'flex w-full' : 'inline-flex',
-    'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/50',
-    variant === 'nav' && 'group-hover:text-yellow-100',
-    variant !== 'nav' && 'hover:text-yellow-50',
+    variant === 'nav' &&
+      'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/50 group-hover:text-yellow-100',
+    variant === 'cta' &&
+      'rounded-lg bg-gradient-to-r from-teal-500 to-cyan-500 px-6 py-3 font-medium text-white shadow-md hover:from-teal-600 hover:to-cyan-600 hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500 focus-visible:ring-offset-2 active:scale-95',
+    variant === 'plain' &&
+      'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/50 hover:text-yellow-50 hover:underline',
     variant === 'mobile' &&
-      'rounded-lg px-2 py-2 text-left hover:bg-white/10 active:bg-white/20',
-    variant === 'plain' && 'hover:underline',
-    isActive && 'text-yellow-50',
-    isActive && variant === 'mobile' && 'bg-white/15',
+      'rounded-lg px-2 py-2 text-left hover:bg-white/10 hover:text-yellow-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/50 active:bg-white/20',
+    isActive && variant === 'nav' && 'text-yellow-50',
+    isActive && variant === 'mobile' && 'bg-white/15 text-yellow-50',
     isNavigating && 'pointer-events-none scale-[0.98] opacity-75',
     className,
   ]

--- a/src/components/results/CommentSection.tsx
+++ b/src/components/results/CommentSection.tsx
@@ -21,11 +21,18 @@ export default function CommentSection({ rideId }: { rideId: number }) {
   const { user } = useAuth()
   const [userDetails, setUserDetails] = useState<UserSummary | null>(null)
 
-  const bottomRef = useRef<HTMLDivElement | null>(null)
+  const scrollContainerRef = useRef<HTMLDivElement | null>(null)
+  const shouldAutoScrollRef = useRef(false)
 
-  // Auto-scroll to bottom when comments update
   useEffect(() => {
-    bottomRef.current?.scrollIntoView({ behavior: 'smooth' })
+    if (!shouldAutoScrollRef.current) return
+
+    const container = scrollContainerRef.current
+    if (container) {
+      container.scrollTop = container.scrollHeight
+    }
+
+    shouldAutoScrollRef.current = false
   }, [commentList])
 
   useEffect(() => {
@@ -62,6 +69,7 @@ export default function CommentSection({ rideId }: { rideId: number }) {
       user: userDetails,
     }
 
+    shouldAutoScrollRef.current = true
     setCommentList((prev) => [...prev, optimisticComment])
     setNewComment('')
 
@@ -87,7 +95,10 @@ export default function CommentSection({ rideId }: { rideId: number }) {
 
   return (
     <div className="mt-4 flex max-h-64 flex-col overflow-hidden rounded-lg border border-gray-200 bg-white shadow-md">
-      <div className="space-y-2 overflow-y-auto p-3 text-sm text-gray-700">
+      <div
+        ref={scrollContainerRef}
+        className="space-y-2 overflow-y-auto p-3 text-sm text-gray-700"
+      >
         {commentList.length > 0 ? (
           commentList.map((comment) => (
             <div
@@ -103,7 +114,6 @@ export default function CommentSection({ rideId }: { rideId: number }) {
         ) : (
           <p className="text-sm text-gray-500">No messages yet.</p>
         )}
-        <div ref={bottomRef} /> {/* 👈 Auto-scroll target */}
       </div>
       <div className="mt-auto flex border-t border-gray-200 px-3 py-2">
         <input


### PR DESCRIPTION
* Header nav: click/hover/active feedback; compact size kept; Dashboard works from /admin/groups
* Results page: no more auto-scroll to bottom on load
* Admin: “View & Manage Groups” button has loading/click feedback